### PR TITLE
JS : add event to anounce control item color change

### DIFF
--- a/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-7-0rc14.js
+++ b/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-7-0rc14.js
@@ -801,6 +801,10 @@ var store_temp_ajax_data = null;
                  }else {
                    e.style.backgroundColor = update_data_colors(control_item_id,val);
                  }
+                 // create event to announce color change for a control item
+                 elem = document.querySelector("div.hidden.controlitem-config2[data-id='" + control_item_id.split('-')[1] + "']");
+                 var event = new CustomEvent("changePyScadaControlItemColor_" + control_item_id.split('-')[1], { detail: update_data_colors(control_item_id,val) });
+                 elem.dispatchEvent(event);
              }
          })
 


### PR DESCRIPTION
event is linked to the control item config2 element 
event name is : "changePyScadaControlItemColor_" + control_item_id 
event.detail is the color formatted as #45bc65