### PR TITLE
fixed page alignment problem in views

### DIFF
--- a/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-7-0rc14.js
+++ b/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-7-0rc14.js
@@ -3076,7 +3076,19 @@ function setAggregatedPeriodList(widget_id, var_id) {
      }
  }
 
+/**
+ * fix the anchor point for page links
+ * @returns void 
+ */
+ function fix_page_anchor() {
+	// fix the page anchor position
+	var navbar_hight = $("#navbar-top").height() + 20;
+	$.each($('.sub-page'),function(key,val){
+		$(val).attr("style","padding-top: " + navbar_hight + "px; margin-top: " + -navbar_hight + "px;");
+    });
+}
 
+ 
  // PROGRESS BAR :
  /**
   * Set the window progress bar
@@ -4019,6 +4031,7 @@ function setAggregatedPeriodList(widget_id, var_id) {
 
      set_loading_state(1, loading_states[1] + 10);
 
+	fix_page_anchor();
 
      // Activate tooltips
      $('[data-toggle*="tooltip"]').tooltip();
@@ -4219,6 +4232,7 @@ function setAggregatedPeriodList(widget_id, var_id) {
              };
              $.browserQueue.add(doBind, this);
        });
+       fix_page_anchor(); // also adjust the anchor points for page refs if nessesary
      });
      set_loading_state(1, loading_states[1] + 10);
 

--- a/pyscada/hmi/templates/base.html
+++ b/pyscada/hmi/templates/base.html
@@ -28,7 +28,7 @@
         <div id="wrap" {% block wrap_config %} {% endblock %}>
             {% block navbar %}
             <!-- Fixed navbar -->
-            <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+            <div id="navbar-top" class="navbar navbar-inverse navbar-fixed-top" role="navigation">
                 <div class="container">
                     <div class="navbar-header">
                         {% block navbar_logo %}{% endblock %}


### PR DESCRIPTION
when the user clicked on the page link in a view a second time the page has been moved so that the top of the page is below the navbar, this was not intended, the page should be hirisontaly aligned at the bottom of the navbar.´