### PR TITLE
add loading page and load config2 on load event, format console.log, kill timeout and xhr on unload

### DIFF
--- a/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-7-0rc14.js
+++ b/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-7-0rc14.js
@@ -3963,34 +3963,34 @@ function fix_page_anchor() {
      }
  });
 
+ set_loading_state(1, 10);
 
- // fix drop down problem
- $( document ).ready(function() {
+document.body.onload = () => init_pyscada_content();
+
+function init_pyscada_content() {
+  console.log("PyScada HMI : fetching hidden config2")
+  fetch('/getHiddenConfig2/' + document.querySelector("body").dataset["viewTitle"] + "/", {
+   method: "POST",
+   headers: {
+     "X-CSRFToken": CSRFTOKEN,
+     "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+   },
+   body: "",
+ }).then((response) => {
+   if (!response.ok) {
+     throw new Error(`HTTP error, status = ${response.status}`);
+   }
+   set_loading_state(1, 20);
+   return response.text();
+ }).then((text) => {
+   document.querySelector("body #wrap #content .hidden.globalConfig2").innerHTML = text;
+   console.log("PyScada HMI : hidden config2 loaded");
+ }).then(() => {
      // show buttons
      $(".loadingAnimation").parent().show();
      $(".AutoUpdateStatus").parent().parent().show();
      $(".ReadAllTask").parent().parent().show();
      $(".AutoUpdateButtonParent").show();
-
-     set_loading_state(1, 20);
-
-     // load hidden config2
-     fetch('/getHiddenConfig2/' + document.querySelector("body").dataset["viewTitle"] + "/", {
-       method: "POST",
-       headers: {
-         "X-CSRFToken": CSRFTOKEN,
-         "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-       },
-       body: "",
-     }).then((response) => {
-       if (!response.ok) {
-         throw new Error(`HTTP error, status = ${response.status}`);
-       }
-       return response.text();
-     }).then((text) => {
-       document.querySelector("body #wrap #content .hidden.globalConfig2").innerHTML = text;
-       console.log("hidden config2 loaded");
-     }).catch((err) => console.log(err));
 
      // init loading states
      set_loading_state(1, 40);
@@ -4289,4 +4289,14 @@ function fix_page_anchor() {
 
      // Fill aggregated lists
      setAggregatedLists();
+ }).then(() => {
+   // PyScada Core JS loaded successfully => send the event for plugins
+   var event = new CustomEvent("PyScadaCoreJSLoaded");
+   document.dispatchEvent(event);
+   console.log("PyScada HMI : dispatch PyScadaCoreJSLoaded event");
+ }).catch((err) => {
+   console.log("PyScada HMI : ", err);
+   console.log("Retrying to init PyScada Core JS in 1 sec...");
+   setTimeout(init_pyscada_content, 1000);
  });
+};

--- a/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-7-0rc14.js
+++ b/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-7-0rc14.js
@@ -3972,6 +3972,26 @@ function fix_page_anchor() {
      $(".ReadAllTask").parent().parent().show();
      $(".AutoUpdateButtonParent").show();
 
+     set_loading_state(1, 20);
+
+     // load hidden config2
+     fetch('/getHiddenConfig2/' + document.querySelector("body").dataset["viewTitle"] + "/", {
+       method: "POST",
+       headers: {
+         "X-CSRFToken": CSRFTOKEN,
+         "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+       },
+       body: "",
+     }).then((response) => {
+       if (!response.ok) {
+         throw new Error(`HTTP error, status = ${response.status}`);
+       }
+       return response.text();
+     }).then((text) => {
+       document.querySelector("body #wrap #content .hidden.globalConfig2").innerHTML = text;
+       console.log("hidden config2 loaded");
+     }).catch((err) => console.log(err));
+
      // init loading states
      set_loading_state(1, 40);
 

--- a/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-7-0rc14.js
+++ b/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-7-0rc14.js
@@ -341,6 +341,16 @@ var ONBEFORERELOAD_ASK = true;
 
 var store_temp_ajax_data = null;
 
+ /**
+  * store all timeout ids for each functions
+  */
+ var PYSCADA_TIMEOUTS = {};
+
+  /**
+   * store current ajax request
+   */
+  var PYSCADA_XHR = null;
+
  //---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  //---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -1065,10 +1075,10 @@ function set_config_from_hidden_config(type,filter_data,val,get_data,value){
          // initialisation is active
          //setTimeout(function() {data_handler();}, REFRESH_RATE/2.0);
          if (STATUS_VARIABLE_KEYS.count() + CHART_VARIABLE_KEYS.count() == 0 && LOADING_PAGE_DONE == 0) {LOADING_PAGE_DONE = 1;show_page();hide_loading_state();}
-         setTimeout(function() {data_handler();}, 100);
+         PYSCADA_TIMEOUTS["data_handler"] = setTimeout(function() {data_handler();}, 100);
      }else{
          if (LOADING_PAGE_DONE == 0) {LOADING_PAGE_DONE = 1;show_page();hide_loading_state();loading_states={};}
-         setTimeout(function() {data_handler();}, REFRESH_RATE);
+         PYSCADA_TIMEOUTS["data_handler"] = setTimeout(function() {data_handler();}, REFRESH_RATE);
      }
  }
 
@@ -1088,7 +1098,7 @@ function set_config_from_hidden_config(type,filter_data,val,get_data,value){
      request_data = {timestamp_from:timestamp_from, variables: variable_keys, init: init, variable_properties:variable_property_keys};
      if (typeof(timestamp_to !== 'undefined')){request_data['timestamp_to']=timestamp_to};
      //if (!init){request_data['timestamp_from'] = request_data['timestamp_from'] - REFRESH_RATE;};
-     $.ajax({
+     PYSCADA_XHR = $.ajax({
          url: ROOT_URL+'json/cache_data/',
          dataType: "json",
          timeout: ((init == 1) ? FETCH_DATA_TIMEOUT*5: FETCH_DATA_TIMEOUT),
@@ -3544,7 +3554,7 @@ function fix_page_anchor() {
 
      show_update_status();
 
-     $.ajax({
+     PYSCADA_XHR = $.ajax({
          url: ROOT_URL+'json/log_data/',
          type: 'post',
          dataType: "json",
@@ -3743,7 +3753,7 @@ function fix_page_anchor() {
      refresh_logo(key, type);
      data_type = $(this).data('type');
      $(this)[0].disabled = true;
-     $.ajax({
+     PYSCADA_XHR = $.ajax({
          type: 'post',
          url: ROOT_URL+'form/read_task/',
          data: {key:key, type:data_type},
@@ -3787,7 +3797,7 @@ function fix_page_anchor() {
              $(this).parents(".input-group").removeClass("has-error")
              if (isNaN(value)) {
                  if (item_type == "variable_property" && value_class == 'STRING'){
-                     $.ajax({
+                     PYSCADA_XHR = $.ajax({
                          type: 'post',
                          url: ROOT_URL+'form/write_property2/',
                          data: {variable_property:key, value:value},
@@ -3803,7 +3813,7 @@ function fix_page_anchor() {
                      $(this).parents(".input-group-btn").after('<span id="helpBlock-' + id + '" class="help-block">The value must be a number ! Use dot not coma.</span>');
                  };
              }else {
-                 $.ajax({
+                 PYSCADA_XHR = $.ajax({
                      type: 'post',
                      url: ROOT_URL+'form/write_task/',
                      data: {key:key, value:value, item_type:item_type},
@@ -3835,7 +3845,7 @@ function fix_page_anchor() {
          if ($(tabinputs[i]).hasClass('btn-success')){
              id = $(tabinputs[i]).attr('id');
              //$('#'+id).removeClass('update-able');
-             $.ajax({
+             PYSCADA_XHR = $.ajax({
                  type: 'post',
                  url: ROOT_URL+'form/write_task/',
                  data: {key:key,value:1,item_type:item_type},
@@ -3848,7 +3858,7 @@ function fix_page_anchor() {
          }else if ($(tabinputs[i]).hasClass('btn-default')){
              id = $(tabinputs[i]).attr('id');
              //$('#'+id).removeClass('update-able');
-             $.ajax({
+             PYSCADA_XHR = $.ajax({
                  type: 'post',
                  url: ROOT_URL+'form/write_task/',
                  data: {key:key,value:0,item_type:item_type},
@@ -3859,7 +3869,7 @@ function fix_page_anchor() {
                  }
              });
          }else{
-             $.ajax({
+             PYSCADA_XHR = $.ajax({
                  type: 'post',
                  url: ROOT_URL+'form/write_task/',
                  data: {key:key, value:value, item_type:item_type},
@@ -3880,7 +3890,7 @@ function fix_page_anchor() {
          item_type = $(tabselects[i]).data('type');
          if (isNaN(value)){
              if (item_type == "variable_property"){
-                 $.ajax({
+                 PYSCADA_XHR = $.ajax({
                      type: 'post',
                      url: ROOT_URL+'form/write_property2/',
                      data: {variable_property:var_name, value:value},
@@ -3895,7 +3905,7 @@ function fix_page_anchor() {
                  add_notification("select is " + item_type + " and not a number",3);
              };
          }else {
-             $.ajax({
+             PYSCADA_XHR = $.ajax({
                  type: 'post',
                  url: ROOT_URL+'form/write_task/',
                  data: {key:key, value:value, item_type:item_type},
@@ -3935,7 +3945,7 @@ function fix_page_anchor() {
      $(".variable-config[data-refresh-requested-timestamp][data-key=" + key + "][data-type=" + item_type + "]").attr('data-refresh-requested-timestamp', SERVER_TIME)
      $(".variable-config2[data-refresh-requested-timestamp][data-id=" + key + "]").attr('data-refresh-requested-timestamp', SERVER_TIME)
      if($(this).hasClass('btn-default')){
-         $.ajax({
+         PYSCADA_XHR = $.ajax({
              type: 'post',
              url: ROOT_URL+'form/write_task/',
              data: {key:key,value:1,item_type:item_type},
@@ -3948,7 +3958,7 @@ function fix_page_anchor() {
              }
          });
      }else if ($(this).hasClass('btn-success')){
-         $.ajax({
+         PYSCADA_XHR = $.ajax({
              type: 'post',
              url: ROOT_URL+'form/write_task/',
              data: {key:key,value:0,item_type:item_type},
@@ -4049,6 +4059,14 @@ function init_pyscada_content() {
          }else {
              return null;
          };
+     };
+     // stop all setTimeout and Ajax requests when leaving
+     window.onunload = function() {
+         for (t in PYSCADA_TIMEOUTS) {clearTimeout(PYSCADA_TIMEOUTS[t]);console.log("PyScada HMI : clearing timeout", t);}
+         if(PYSCADA_XHR != null && PYSCADA_XHR.readyState != 4){
+             PYSCADA_XHR.abort();
+             console.log("PyScada HMI : aborting xhr")
+         }
      };
      $(window).on('hashchange', function() {
          // nav menu click event
@@ -4181,7 +4199,7 @@ function init_pyscada_content() {
          set_chart_selection_mode();
      });
 
-     setTimeout(function() {data_handler();}, 5000);
+     PYSCADA_TIMEOUTS["data_handler"] = setTimeout(function() {data_handler();}, 5000);
      set_chart_selection_mode();
 
 
@@ -4207,7 +4225,7 @@ function init_pyscada_content() {
 
      // Send request data to all devices
      $('.ReadAllTask').click(function(e) {
-       $.ajax({
+       PYSCADA_XHR = $.ajax({
            url: ROOT_URL+'form/read_all_task/',
            type: "POST",
            data:{},

--- a/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-7-0rc14.js
+++ b/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-7-0rc14.js
@@ -418,10 +418,10 @@ var store_temp_ajax_data = null;
                              if (typeof(start_id) === "number" ){
                                  DATA[key] = value.slice(0,start_id).concat(DATA[key]);
                              }else{
-                                 console.log(key + ' : dropped data');
+                                 console.log("PyScada HMI : var" , key, ": dropped data, start_id not found.", value, DATA[key][0][0]);
                              }
                          }else{
-                             console.log(key + ' : dropped data');
+                             console.log("PyScada HMI : var" , key, ": dropped data, stop_id not found.", value, DATA[key][DATA[key].length-1][0]);
                          }
                      }
 
@@ -432,7 +432,7 @@ var store_temp_ajax_data = null;
                          if (typeof(stop_id) === "number" ){
                              DATA[key] = value.slice(0,stop_id).concat(DATA[key]);
                          }else{
-                             console.log(key + ' : dropped data');
+                             console.log("PyScada HMI : var" , key, ": dropped data, stop_id not found.", value, DATA[key][0][0]);
                          }
                      } else if (v_t_max > d_t_max && d_t_min < v_t_min){
                          // data and value overlapping, data has older elements than value, append
@@ -440,10 +440,10 @@ var store_temp_ajax_data = null;
                          if (typeof(stop_id) === "number" ){
                              DATA[key] = DATA[key].concat(value.slice(stop_id));
                          }else{
-                             console.log(key + ' : dropped data');
+                             console.log("PyScada HMI : var" , key, ": dropped data, stop_id not found.", value, DATA[key][DATA[key].length-1][0]);
                          }
                      } else{
-                         //console.log(key + ' : no new data');
+                         console.log("PyScada HMI : var" , key, ' : no new data, drop.');
                      }
                  }
 
@@ -563,7 +563,10 @@ var store_temp_ajax_data = null;
      }
 
      function rgbToHex(rgb) {
-         if (typeof rgb != "object" || rgb.constructor != Array || rgb.length != 3) {console.log(typeof rgb, rgb.constructor, rgb.length, rgb);return;}
+         if (typeof rgb != "object" || rgb.constructor != Array || rgb.length != 3) {
+           console.log("PyScada HMI : cannot update data colors, rgb to hex error :", typeof rgb, rgb.constructor, rgb.length, rgb);
+           return;
+         }
          r = rgb[0]
          g = rgb[1]
          b = rgb[2]
@@ -932,7 +935,7 @@ function set_config_from_hidden_config(type,filter_data,val,get_data,value){
          INIT_CHART_VARIABLES_COUNT++;
          vars.push(key);
          dpi = get_config_from_hidden_config('device','id',get_config_from_hidden_config('variable','id',key,'device') ,'polling-interval');
-         if (! isNaN(dpi)) {device_pulling_interval_sum += parseFloat(dpi);var_count_poll++;}else {console.log("ConfigV2 not found for var " + key);};
+         if (! isNaN(dpi)) {device_pulling_interval_sum += parseFloat(dpi);var_count_poll++;}else {console.log("PyScada HMI : ConfigV2 not found for var", key);};
          if (typeof(DATA[key]) == 'object'){
              timestamp = Math.max(timestamp,DATA[key][0][0]);
          }else{
@@ -1465,21 +1468,24 @@ function createOffset(date) {
                     (14, 'distinct count'),
  */
  function get_aggregated_data(key, start, stop, type=6, min_aggregate=3) {
-    if (!Number.isInteger(key) || Number.isNaN(start) || Number.isNaN(stop) || !Number.isInteger(type) || !Number.isInteger(min_aggregate)) {console.log("get_aggregated_data : a param is not a int, number, number, int : ", key, start, stop, type);return key;};
+    if (!Number.isInteger(key) || Number.isNaN(start) || Number.isNaN(stop) || !Number.isInteger(type) || !Number.isInteger(min_aggregate)) {
+      console.log("PyScada HMI : get_aggregated_data : params types are not int, number, number, int : ", key, start, stop, type);
+      return key;
+    };
     key = Number(key);
     start = Number(start);
     stop = Number(stop);
     type = Number(type);
     min_aggregate = parseInt(min_aggregate);
-    if (min_aggregate <= 0) {console.log("min_aggregate should be > 0, it is ", min_aggregate);return key;};
-    if (!key in DATA) {console.log(key, "not in DATA");return key;};
+    if (min_aggregate <= 0) {console.log("PyScada HMI : min_aggregate should be > 0, it is ", min_aggregate);return key;};
+    if (!key in DATA) {console.log("PyScada HMI :", key, "not in DATA");return key;};
     //if (start < 0 || stop < 0) {console.log("start or stop < 0 :", start, stop);};
     if (start < 0) {start = DATA_FROM_TIMESTAMP;};
     if (stop < 0) {stop = DATA_TO_TIMESTAMP;};
     start = start / 1000;
     stop = stop / 1000;
-    if (start >= stop) {console.log("start is not < stop :", start, stop);return key;};
-    if (type < 0 || type > 14) {console.log("type is not 0 between and 14 included :", type)};
+    if (start >= stop) {console.log("PyScada HMI : start is not < stop :", start, stop);return key;};
+    if (type < 0 || type > 14) {console.log("PyScada HMI : type is not 0<= and >=14 :", type)};
 
     periodFields = get_period_fields(key);
     validPeriodFields = filter_period_fields_by_type(periodFields, type);

--- a/pyscada/hmi/templates/svg_loading_icon.html
+++ b/pyscada/hmi/templates/svg_loading_icon.html
@@ -1,0 +1,32 @@
+<!-- By Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL -->
+<svg fill="#{{ svg_loading_color|default:"000" }}" width="38" height="38" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+      <linearGradient x1="8.042%" y1="0%" x2="65.682%" y2="23.865%" id="a">
+          <stop stop-color="#{{ svg_loading_color|default:"000" }}" stop-opacity="0" offset="0%"/>
+          <stop stop-color="#{{ svg_loading_color|default:"000" }}" stop-opacity=".631" offset="63.146%"/>
+          <stop stop-color="#{{ svg_loading_color|default:"000" }}" offset="100%"/>
+      </linearGradient>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+      <g transform="translate(1 1)">
+          <path d="M36 18c0-9.94-8.06-18-18-18" id="Oval-2" stroke="url(#a)" stroke-width="2">
+              <animateTransform
+                  attributeName="transform"
+                  type="rotate"
+                  from="0 18 18"
+                  to="360 18 18"
+                  dur="0.9s"
+                  repeatCount="indefinite" />
+          </path>
+          <circle fill="#{{ svg_loading_color|default:"000" }}" cx="36" cy="18" r="1">
+              <animateTransform
+                  attributeName="transform"
+                  type="rotate"
+                  from="0 18 18"
+                  to="360 18 18"
+                  dur="0.9s"
+                  repeatCount="indefinite" />
+          </circle>
+      </g>
+  </g>
+</svg>

--- a/pyscada/hmi/templates/view.html
+++ b/pyscada/hmi/templates/view.html
@@ -90,6 +90,12 @@
             <tbody></tbody>
         </table>
     </div> <!-- end page-log -->
+    {% block loading_page %}
+    <!-- start page-loading -->
+    <div id="page-loading" class="sub-page" style="display: flex; align-items: center; justify-content: center;">
+          {% include "svg_loading_icon.html" %}
+    </div> <!-- end page-loading -->
+    {% endblock loading_page %}
     {% for panel in panel_list %}
         <div class="side-menu  {% if panel.position == 1 %}left{% elif panel.position == 2 %}right{% endif %}">
             <ul class="status-panel">

--- a/pyscada/hmi/templates/view.html
+++ b/pyscada/hmi/templates/view.html
@@ -9,7 +9,7 @@
 {% endfor %}
 {% endblock %}
 
-{% block body_confic_data %} data-data-file="json/cache_data/" {% endblock %}
+{% block body_confic_data %} data-data-file="json/cache_data/" data-view-title="{{ view_link_title }}" {% endblock %}
 
 {% block top_menu_left %}
     {% for page in page_list %}

--- a/pyscada/hmi/urls.py
+++ b/pyscada/hmi/urls.py
@@ -41,4 +41,9 @@ urlpatterns = [
     path("form/read_all_task/", views.form_read_all_task),
     path("form/write_property2/", views.form_write_property2),
     path("view/<link_title>/", views.view, name="main-view"),
+    path(
+        "getHiddenConfig2/<link_title>/",
+        views.get_hidden_config2,
+        name="get-hidden-config2",
+    ),
 ]


### PR DESCRIPTION
- add PyScada HMI at the beginning of each console.log
- kill setTimeout and xhr request on page unload:
  - store all timeouts in the PYSCADA_TIMEOUTS dictionary
  - store the current xhr blocking request in PYSCADA_XHR variable
- add loading page with svg icon:
  - can be replaced by the loading_page block
  - default icon color (000, black) can be change with svg_loading_color
  - for example: svg_loading_color="00f"
- load config2 after html load and before the pyscada hmi init, then send event:
  - to load the view quickly load the hidden config2 after the loading the view html code
  - Init the pyscada hmi
  - send PyScadaCoreJSLoaded for plugins