### PR TITLE
prevent loading and showing data after DATA_TO_TIMESTAMP

### DIFF
--- a/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-7-0rc14.js
+++ b/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-7-0rc14.js
@@ -1033,6 +1033,7 @@ function set_config_from_hidden_config(type,filter_data,val,get_data,value){
                              //var timestamp = SERVER_TIME;
                              timestamp = DATA_TO_TIMESTAMP;
                          }
+                         timestamp = Math.min(timestamp, DATA_TO_TIMESTAMP)  // prevent loading and showing data after DATA_TO_TIMESTAMP
                          request_duration = timestamp - DATA_FROM_TIMESTAMP
                          // Fetch 1 000 points by var
                          point_quantity_to_fetch_by_var = 1000;


### PR DESCRIPTION
the bug was that the timestamp_to for the data handler ajax query could be higher than DATA_TO_TIMESTAMP and then change the datepicker end value after the ajax request finish