### PR TITLE
utc import from datetime

### DIFF
--- a/pyscada/migrations/0083_auto_20211115_0812.py
+++ b/pyscada/migrations/0083_auto_20211115_0812.py
@@ -2,7 +2,7 @@
 
 import datetime
 from django.db import migrations, models
-from django.utils.timezone import utc
+from datetime import timezone
 
 
 class Migration(migrations.Migration):
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             model_name="periodfield",
             name="start_from",
             field=models.DateTimeField(
-                default=datetime.datetime(2021, 11, 15, 0, 0, tzinfo=utc),
+                default=datetime.datetime(2021, 11, 15, 0, 0, tzinfo=timezone.utc),
                 help_text="Count from this DateTime and then each period_factor*periodcalculate between 1min30 and 2min30 etc.",
             ),
         ),

--- a/pyscada/migrations/0086_auto_20211115_1612.py
+++ b/pyscada/migrations/0086_auto_20211115_1612.py
@@ -2,7 +2,7 @@
 
 import datetime
 from django.db import migrations, models
-from django.utils.timezone import utc
+from datetime import timezone
 
 
 class Migration(migrations.Migration):
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
             model_name="periodicfield",
             name="start_from",
             field=models.DateTimeField(
-                default=datetime.datetime(2021, 11, 15, 0, 0, tzinfo=utc),
+                default=datetime.datetime(2021, 11, 15, 0, 0, tzinfo=timezone.utc),
                 help_text="Calculate from this DateTime and then each period_factor*period",
             ),
         ),

--- a/pyscada/migrations/0087_auto_20211116_1329.py
+++ b/pyscada/migrations/0087_auto_20211116_1329.py
@@ -2,7 +2,7 @@
 
 import datetime
 from django.db import migrations, models
-from django.utils.timezone import utc
+from datetime import timezone
 
 
 class Migration(migrations.Migration):
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
             model_name="periodicfield",
             name="start_from",
             field=models.DateTimeField(
-                default=datetime.datetime(2021, 11, 16, 0, 0, tzinfo=utc),
+                default=datetime.datetime(2021, 11, 16, 0, 0, tzinfo=timezone.utc),
                 help_text="Calculate from this DateTime and then each period_factor*period",
             ),
         ),

--- a/pyscada/migrations/0088_auto_20211117_1023.py
+++ b/pyscada/migrations/0088_auto_20211117_1023.py
@@ -2,7 +2,7 @@
 
 import datetime
 from django.db import migrations, models
-from django.utils.timezone import utc
+from datetime import timezone
 
 
 class Migration(migrations.Migration):
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
             model_name="periodicfield",
             name="start_from",
             field=models.DateTimeField(
-                default=datetime.datetime(2021, 11, 17, 0, 0, tzinfo=utc),
+                default=datetime.datetime(2021, 11, 17, 0, 0, tzinfo=timezone.utc),
                 help_text="Calculate from this DateTime and then each period_factor*period",
             ),
         ),

--- a/pyscada/migrations/0091_auto_20211118_1019.py
+++ b/pyscada/migrations/0091_auto_20211118_1019.py
@@ -2,7 +2,7 @@
 
 import datetime
 from django.db import migrations, models
-from django.utils.timezone import utc
+from datetime import timezone
 
 
 class Migration(migrations.Migration):
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             model_name="periodicfield",
             name="start_from",
             field=models.DateTimeField(
-                default=datetime.datetime(2021, 11, 18, 0, 0, tzinfo=utc),
+                default=datetime.datetime(2021, 11, 18, 0, 0, tzinfo=timezone.utc),
                 help_text="Calculate from this DateTime and then each period_factor*period",
             ),
         ),


### PR DESCRIPTION
The django.utils.timezone.utc alias to datetime.timezone.utc is removed in django 5.0.

see
https://docs.djangoproject.com/en/5.0/releases/5.0/#features-removed-in-5-0