### PR TITLE
added option to set a custom message for processes

### DIFF
--- a/pyscada/utils/scheduler.py
+++ b/pyscada/utils/scheduler.py
@@ -761,6 +761,7 @@ class Process(object):
         self.label = ""
         self.dwt_received = False
         self.drt_received = False
+        self.next_message = "running.."
         # register signals
         self.SIG_QUEUE = []
         self.SIGNALS = [signal.SIGTERM, signal.SIGUSR1, signal.SIGHUP, signal.SIGUSR2]
@@ -801,7 +802,7 @@ class Process(object):
 
     def run(self):
         BackgroundProcess.objects.filter(pk=self.process_id).update(
-            last_update=now(), message="running.."
+            last_update=now(), message=self.next_message
         )
         exec_loop = True
         try:
@@ -815,7 +816,7 @@ class Process(object):
 
                 # update progress
                 BackgroundProcess.objects.filter(pk=self.process_id).update(
-                    last_update=now()
+                    last_update=now(), message=self.next_message
                 )
                 if sig is None and exec_loop:
                     # run loop action


### PR DESCRIPTION
run by the background-process scheduler, this is e.g. useful for keeping track of the state of single shot tasks.