### PR TITLE
fixed all values=0 in, filename is None error, h5 timestamp format da…

### DIFF
--- a/pyscada/export/models.py
+++ b/pyscada/export/models.py
@@ -116,6 +116,9 @@ class ExportTask(models.Model):
                 backup_file_path = os.path.expanduser(
                     settings.PYSCADA_EXPORT["output_folder"]
                 )
+        if self.filename is None:
+            return "error, file not exported"
+
         return mark_safe(
             '<a href="%s">%s</a>'
             % (

--- a/pyscada/export/worker.py
+++ b/pyscada/export/worker.py
@@ -81,7 +81,10 @@ class ExportProcess(BaseProcess):
         if bp:
             bp.done = True
             bp.last_update = now()
-            bp.message = "stopped"
+
+            if not bp.failed:
+                bp.message = "stopped"
+
             bp.save()
 
         return 0, None


### PR DESCRIPTION
…ta export

- export jobs will be markt as faild now
- the min and max time check is removed because it only checks the first variable
- fixed unit mismatch timestamps from read_multiple in ms, export expected them in s
- added more detailted status output to backgroundtask model
- changed timestamp format for h5 output from matlab to unix timestamps
- escape of "/" in variable name to prevent dataset generation in h5 and mat files