### PR TITLE
fixes "Invalid Date" error in HMI

### DIFF
--- a/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-8-3.js
+++ b/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-8-3.js
@@ -1289,7 +1289,7 @@ function createOffset(date) {
      // update data timestamp
      if(DATA_TO_TIMESTAMP==0){
          //DATA_TO_TIMESTAMP = DATA_FROM_TIMESTAMP = SERVER_TIME;
-         DEFAULT_TIME_DELTA = document.querySelector("body").getAttribute("data-view-time-delta") == null ? 7200 : document.querySelector("body").getAttribute("data-view-time-delta");
+         DEFAULT_TIME_DELTA = document.querySelector("body").getAttribute("data-view-time-delta") == null ? 7200 : parseFloat(document.querySelector("body").getAttribute("data-view-time-delta"));
          DATA_TO_TIMESTAMP = SERVER_TIME;
          DATA_FROM_TIMESTAMP = SERVER_TIME - DEFAULT_TIME_DELTA * 1000;
      }else{


### PR DESCRIPTION
this bug happend only when the Server LOCAL was set to a location that uses "," for decimals because in this case the implicit conversion from string to float failed ("7200,0" * 1 => NaN)