### PR TITLE
move app init to scheduler and allow cov handling by plugins

### DIFF
--- a/pyscada/apps.py
+++ b/pyscada/apps.py
@@ -20,6 +20,8 @@ class PyScadaConfig(AppConfig):
     def ready(self):
         import pyscada.signals
 
+    def pyscada_app_init(self):
+        logger.debug("Core init app")
         try:
             from .hmi.models import Theme
 

--- a/pyscada/core/urls.py
+++ b/pyscada/core/urls.py
@@ -8,10 +8,10 @@ logger = logging.getLogger(__name__)
 
 urlpatterns = []
 
-for app in apps.app_configs.values():
-    if app.name.startswith("pyscada.") and app.name != "pyscada.core":
+for app_config in apps.get_app_configs():
+    if app_config.name.startswith("pyscada.") and app_config.name != "pyscada.core":
         try:
-            m = __import__(f"{app.name}.urls", fromlist=[str("a")])
+            m = __import__(f"{app_config.name}.urls", fromlist=[str("a")])
             urlpatterns += m.urlpatterns
         except ModuleNotFoundError:
             pass

--- a/pyscada/hmi/apps.py
+++ b/pyscada/hmi/apps.py
@@ -19,6 +19,8 @@ class PyScadaHMIConfig(AppConfig):
     def ready(self):
         import pyscada.hmi.signals
 
+    def pyscada_app_init(self):
+        logger.debug("HMI init app")
         try:
             from .models import TransformData
 

--- a/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-8-3.js
+++ b/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-8-3.js
@@ -138,6 +138,12 @@ Licensed under the AGPL.
  var AUTO_UPDATE_ACTIVE = true;
 
  /**
+  * Use synchronous data handling
+  * @type {boolean}
+  */
+ var SYNC_HANDLING_DATA = true;
+
+ /**
   * Previous auto chart's data update button active
   * @type {boolean}
   */
@@ -1334,7 +1340,7 @@ function createOffset(date) {
      }
      UPDATE_STATUS_COUNT = 0;
      //hide_update_status();
-     if(request_data.init===1){
+     if(typeof request_data != "undefined" && request_data.init===1){
          hide_init_status();
      }
      //FETCH_DATA_PENDING--;
@@ -1370,7 +1376,7 @@ function createOffset(date) {
          }
      }
      //hide_update_status();
-     if(request_data.init===1){
+     if(typeof request_data != "undefined" && request_data.init===1){
          for (key in request_data.variables){
              key = request_data.variables[key];
              if (typeof(CHART_VARIABLE_KEYS[key]) === 'number'){
@@ -4442,7 +4448,10 @@ function init_pyscada_content() {
          set_chart_selection_mode();
      });
 
-     PYSCADA_TIMEOUTS["data_handler"] = setTimeout(function() {data_handler();}, 5000);
+
+     if (SYNC_HANDLING_DATA) {
+        PYSCADA_TIMEOUTS["data_handler"] = setTimeout(function() {data_handler();}, 5000);
+     }
      set_chart_selection_mode();
 
 

--- a/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-8-3.js
+++ b/pyscada/hmi/static/pyscada/js/pyscada/pyscada_v0-8-3.js
@@ -1283,9 +1283,15 @@ function createOffset(date) {
      }
 
      if (typeof(fetched_data['variable_properties'])==="object"){
-         VARIABLE_PROPERTIES_DATA = fetched_data['variable_properties'];
+         //VARIABLE_PROPERTIES_DATA = fetched_data['variable_properties'];
+         for (vp_key in fetched_data['variable_properties']){
+            VARIABLE_PROPERTIES_DATA[vp_key] = fetched_data['variable_properties'][vp_key]
+         }
          delete fetched_data['variable_properties'];
-         VARIABLE_PROPERTIES_LAST_MODIFIED = fetched_data['variable_properties_last_modified'];
+         //VARIABLE_PROPERTIES_LAST_MODIFIED = fetched_data['variable_properties_last_modified'];
+         for (vp_key in fetched_data['variable_properties_last_modified']){
+            VARIABLE_PROPERTIES_LAST_MODIFIED[vp_key] = fetched_data['variable_properties_last_modified'][vp_key]
+         }
          delete fetched_data['variable_properties_last_modified'];
      }else{
          VARIABLE_PROPERTIES_DATA = {};

--- a/pyscada/hmi/views.py
+++ b/pyscada/hmi/views.py
@@ -566,17 +566,8 @@ def view(request, link_title):
                     object_config_list[obj._meta.model_name] = list()
                 if obj not in object_config_list[obj._meta.model_name]:
                     object_config_list[obj._meta.model_name].append(obj)
-    # Generate html object hidden config
+    # Add html object hidden config div so that it can be filled in later
     pages_html += '<div class="hidden globalConfig2">'
-    for model, val in sorted(object_config_list.items(), key=lambda ele: ele[0]):
-        pages_html += '<div class="hidden ' + str(model) + 'Config2">'
-        for obj in val:
-            pages_html += gen_hiddenConfigHtml(
-                obj,
-                custom_fields_list.get(model, None),
-                exclude_fields_list.get(model, None),
-            )
-        pages_html += "</div>"
     pages_html += "</div>"
 
     context = {

--- a/pyscada/models.py
+++ b/pyscada/models.py
@@ -667,7 +667,7 @@ class RecordedDataManager(models.Manager):
             for pk in variable_ids:
                 if pk not in values:
                     values[pk] = []
-                time_max_last_value = time.time()
+                time_max_last_value = time_max
                 if pk in times:
                     time_max_last_value = times[pk]["time_min"]
                 last_element = self.last_element(

--- a/pyscada/models.py
+++ b/pyscada/models.py
@@ -112,7 +112,7 @@ class RecordedDataManager(models.Manager):
                 else now()
             )
             return RecordedData(
-                timestamp=timestamp,
+                timestamp=timestamp/1000,
                 variable=variable,
                 value=value,
                 date_saved=date_saved,
@@ -1638,7 +1638,7 @@ class DjangoDatabase(models.Model):
                         item.date_saved = date_saved
                     # create the recorded data object
                     rc = data_model.objects.create_data_element_from_variable(
-                        item, cached_value[0], cached_value[1], **kwargs
+                        item, cached_value[1], cached_value[0], **kwargs
                     )
                     # append the object to the elements to save
                     if rc is not None:
@@ -2020,7 +2020,7 @@ class Variable(models.Model):
         update_false_count = 0
         for i in range(0, len(value_list)):
             if self._update_value(value_list[i], timestamp_list[i]):
-                self.cached_values_to_write.append((self.value, self.timestamp))
+                self.cached_values_to_write.append((self.timestamp*1000, self.value))
             else:
                 update_false_count += 1
             has_value = True

--- a/pyscada/signals.py
+++ b/pyscada/signals.py
@@ -15,9 +15,6 @@ from django.dispatch import receiver
 from django.db.models.signals import (
     post_save,
     pre_delete,
-    pre_save,
-    m2m_changed,
-    post_delete,
 )
 
 import signal

--- a/pyscada/utils/scheduler.py
+++ b/pyscada/utils/scheduler.py
@@ -65,6 +65,7 @@ from django.db.utils import OperationalError
 from django.db.transaction import TransactionManagementError
 from django.db.models import Q
 from django.db.utils import IntegrityError
+from django.utils.timezone import now
 
 from pyscada.models import (
     BackgroundProcess,
@@ -75,7 +76,6 @@ from pyscada.models import (
     VariableProperty,
 )
 from pyscada.utils import set_bit
-from django.utils.timezone import now
 import logging
 
 logger = logging.getLogger(__name__)

--- a/pyscada/utils/scheduler.py
+++ b/pyscada/utils/scheduler.py
@@ -364,7 +364,7 @@ class Scheduler(object):
         self.pid = getpid()
         if not master_process:
             self.delete_pid(force_del=True)
-            logger.debug("no such process in BackgroundProcesses\n")
+            logger.error("No such scheduler process in BackgroundProcesses")
             sys.exit(0)
 
         # kill all the sub processes
@@ -372,7 +372,7 @@ class Scheduler(object):
             try:
                 kill(process.pid, 9)
             except Exception as e:
-                logger.debug(f"{e} for pid {process.pid}")
+                logger.debug(f"{e} for pid {process.pid} {process.label}")
         # Init the DB
         if not self.init_db():
             logger.debug("Init DB failed\n")


### PR DESCRIPTION
- in order to allow plugin to run code at start and not use the AppConfig.ready function
- a plugin can define a function to custom send cov notification. Add it in AppConfig as: pyscada_send_cov_notification(self, variable)

other fix: 
- [fix time max to find previous last element](https://github.com/pyscada/PyScada/commit/177fe5b3555d6273592e1aed0ae45ed258f7d88f)