### PR TITLE
fixed problem with wrong calulation of date_saved_max

### DIFF
--- a/pyscada/models.py
+++ b/pyscada/models.py
@@ -393,7 +393,7 @@ class RecordedDataManager(models.Manager):
                 tmp_time = tmp_time * f_time_scale
                 date_saved_max = max(
                     date_saved_max,
-                    time.mktime(item[7].utctimetuple()) + item[7].microsecond / 1e6,
+                    item[7].timestamp(),
                 )
                 if item[2] is not None:  # float64
                     values[item[0]].append([tmp_time, item[2]])  # time, value
@@ -624,7 +624,7 @@ class RecordedDataManager(models.Manager):
 
         values = dict()
         times = dict()
-        date_saved_max = 0
+        date_saved_max = time_min
         tmp_time_max = 0
         tmp_time_min = time_max
 
@@ -654,7 +654,7 @@ class RecordedDataManager(models.Manager):
             )  # calc the timestamp in seconds
             date_saved_max = max(
                 date_saved_max,
-                time.mktime(item[7].utctimetuple()) + item[7].microsecond / 1e6,
+                item[7].timestamp(),
             )
             tmp_time_max = max(tmp_time, tmp_time_max)
             tmp_time_min = min(tmp_time, tmp_time_min)
@@ -2036,6 +2036,11 @@ class Variable(models.Model):
             # value has changed
             self.store_value = True
             self.timestamp_old = self.timestamp
+
+        if hasattr(
+            self, "date_saved"
+        ):  # FIXME check if right place to update date_saved
+            self.date_saved = now()
         self.prev_value = self.value
         return self.store_value
 


### PR DESCRIPTION
this fixes the problem that date_saved_max is only updated in the first loop of the device task, this is a problem because the HMI loads the current data in the range date_saved_max to now(), so after some days since the last restart of the pyscada daemon a huge amout of data will be loaded every 5 from the HMI. This is a intermediate Fix until a better solution is found.